### PR TITLE
Updated keybindings to support Win32 and Linux

### DIFF
--- a/keymaps/svgo.cson
+++ b/keymaps/svgo.cson
@@ -1,3 +1,8 @@
 'atom-workspace':
   'ctrl-shift-o': 'svgo:minify'
+
+'.platform-darwin atom-workspace':
   'ctrl-option-o': 'svgo:prettify'
+
+'.platform-win32 atom-workspace, .platform-win32 atom-workspace':
+  'ctrl-alt-o': 'svgo:prettify'


### PR DESCRIPTION
Thanks for making SVGO available within the Atom environment, I receive an error message in the console when loading the package on Windows 10: `Invalid Keybinding: ctrl-option-o` subsequently prettify isn't bound automatically.  This PR introduces platform specific keybindings for Windows, OSX and Linux which should make cross platform use frictionless.